### PR TITLE
Added tests for morph_gps

### DIFF
--- a/R/morph_gps.R
+++ b/R/morph_gps.R
@@ -26,12 +26,8 @@ morph_gps <- function(
                       meta = list(),
                       extra = character()) {
   #  check x
-  # assertthat::assert_that(assertthat::not_empty(x))
-  # assertthat::assert_that(is.data.frame(x))
-  # #  Check id, lat, lon
-  # assertthat::assert_that(assertthat::is.string(id_col))
-  # assertthat::assert_that(assertthat::is.string(lat_col))
-  # assertthat::assert_that(assertthat::is.string(lon_col))
+  assertthat::assert_that(assertthat::not_empty(x))
+  assertthat::assert_that(is.data.frame(x))
   #  Check meta
   assertthat::assert_that(is.list(meta) | is.null(meta))
   assertthat::assert_that(length(names(meta)) == length(meta))
@@ -44,6 +40,7 @@ morph_gps <- function(
     paste0("Column ", deparse(call$x), " must be unquoted. If special characters or spaces exist use back ticks (`A B`).")
   }
 
+  # check unquo
   assertthat::assert_that(is_unquo(id_col))
   assertthat::assert_that(is_unquo(dt_col))
   assertthat::assert_that(is_unquo(lat_col))

--- a/tests/testthat/test-morph_gps.R
+++ b/tests/testthat/test-morph_gps.R
@@ -1,5 +1,126 @@
 context("test-morph_gps.R")
 
-test_that("multiplication works", {
-  expect_equal(2 * 2, 4)
+test_that("Check morph_gps", {
+
+  dat <-
+    system.file("extdata/vectronics.csv", package = "collar") %>%
+    collar::fetch_csv(.) %>%
+    dplyr::mutate(dt_col = paste(utc_date, utc_time))
+
+  dat_morph <-
+    morph_gps(
+      x = dat,
+      id_col = collarid,
+      dt_col = dt_col,
+      dt_format = "%m/%d%Y %H:%M:%S",
+      lon_col = `longitude[°]`,
+      lat_col =`latitude[°]`
+    )
+
+  expect_error(
+    morph_gps()
+  )
+
+  expect_error(
+    morph_gps(x = "A")
+  )
+
+  expect_error(
+    morph_gps(x = dat, id_col = "id")
+  )
+
+  expect_s3_class(
+    dat_morph,
+    "data.frame"
+  )
+
+  expect_true(ncol(dat_morph) == 4)
+
+  expect_true(nrow(dat) == nrow(dat_morph))
+
+})
+
+test_that("Check morph_gps assertions", {
+
+  dat <-
+    system.file("extdata/vectronics.csv", package = "collar") %>%
+    collar::fetch_csv(.) %>%
+    dplyr::mutate(dt = paste(utc_date, utc_time))
+
+
+  # no data
+  expect_condition(
+    morph_gps(),
+    "x has an empty dimension"
+  )
+
+  # not a data frame
+    expect_condition(
+    morph_gps("a"),
+    "x is not a data frame"
+  )
+
+  # meta not a list
+  expect_condition(
+    morph_gps(
+      x = dat,
+      id_col = collarid,
+      dt_col = utc_date,
+      dt_format = "%m/%d%Y %H:%M:%S",
+      lon_col = `longitude[°]`,
+      lat_col =`latitude[°]`,
+      meta = "a"
+    ),    "is.list(meta) | is.null(meta) is not TRUE"
+  )
+
+  # column names are qouted
+  expect_condition(
+    morph_gps(
+      x = dat,
+      id_col = NULL,
+      dt_col = utc_date,
+      dt_format = "%m/%d%Y %H:%M:%S",
+      lon_col = `longitude[°]`,
+      lat_col =`latitude[°]`
+    ),
+    "Column id_col must be unquoted. If special characters or spaces exist use back ticks (`A B`)."
+  )
+
+  expect_condition(
+    morph_gps(
+      x = dat,
+      id_col = collarid,
+      dt_col = NULL,
+      dt_format = "%m/%d%Y %H:%M:%S",
+      lon_col = `longitude[°]`,
+      lat_col =`latitude[°]`
+    ),
+    "Column dt_col must be unquoted. If special characters or spaces exist use back ticks (`A B`)."
+  )
+
+
+  expect_condition(
+    morph_gps(
+      x = dat,
+      id_col = collarid,
+      dt_col = utc_date,
+      dt_format = "%m/%d%Y %H:%M:%S",
+      lon_col = NULL,
+      lat_col =`latitude[°]`
+    ),
+    "Column lon_col must be unquoted. If special characters or spaces exist use back ticks (`A B`)."
+  )
+
+  expect_condition(
+    morph_gps(
+      x = dat,
+      id_col = collarid,
+      dt_col = utc_date,
+      dt_format = "%m/%d%Y %H:%M:%S",
+      lon_col = `longitude[°]`,
+      lat_col = NULL
+    ),
+    "Column lat_col must be unquoted. If special characters or spaces exist use back ticks (`A B`)."
+  )
+
 })


### PR DESCRIPTION
@Huh I am having issues testing and was hoping you can provide some insight.

1. Although I could work around this, the test is failing to recognize the latitude column from the Vectronics csv (due to special characters?).  What has me irked is that it works outside of the test environment.

`Evaluation error: object 'longitude[�]' not found.`

2. When testing assertions the test fails due to an 'unexpected message' although the messages appear to be identical.

```r
test-morph_gps.R:78: failure: Check morph_gps assertions
`morph_gps(...)` threw an condition with unexpected message.
Expected match: "Column id_col must be unquoted. If special characters or spaces exist use back ticks (`A B`)."
Actual message: "Column id_col must be unquoted. If special characters or spaces exist use back ticks (`A B`)."
```

Thanks!