### PR TITLE
Make ats_logout() resilient to Windows schannel TLS error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: collar
 Title: Utilities for Accessing and Manipulating GPS Data
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: c(
   person("Josh", "Nowak", email = "josh.nowak@speedgoat.io", role = c("aut", "cre")),
   person("Forest", "Hayes", email = "forest.hayes@umontana.edu", role = "aut"),
@@ -17,7 +17,7 @@ BugReports: https://github.com/Huh/collar/issues
 Encoding: UTF-8
 LazyData: true
 ByteCompile: true
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Imports:
     assertthat,
     curl,
@@ -44,8 +44,9 @@ Imports:
     tidyr,
     xml2,
     lubridate
-Suggests: 
+Suggests:
     testthat,
     knitr,
+    mockery,
     rmarkdown
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# collar 0.0.7
+
+* `ats_logout()` no longer errors on Windows when the logout request fails with a schannel `SEC_E_CONTEXT_EXPIRED` error under newer libcurl (bundled with R >= 4.5); the transport error is now caught and the local session is cleared by resetting the connection handle (curl#18029).
+
 # collar 0.0.4
 
 * updates ATS functionality to work with redesigned website

--- a/R/ats_auth.R
+++ b/R/ats_auth.R
@@ -98,9 +98,18 @@ ats_login <- function(usr, pwd) {
 
 #' @title Close ATS Session
 #'
-#' @description Logs out of website
+#' @description Logs out of the ATS website and clears the local session.
 #'
-#' @return True if log out request is successful, false if log out fails
+#' @section Notes:
+#'
+#'   The server-side logout request is best-effort. On Windows, newer versions
+#'   of libcurl (bundled with R >= 4.5) can fail the request with a schannel
+#'   \code{SEC_E_CONTEXT_EXPIRED} error on a reused TLS connection (\code{curl}
+#'   issue 18029) even though the session is closed on the server. That
+#'   transport error is caught and ignored; the local session is always cleared
+#'   by resetting the connection handle.
+#'
+#' @return \code{TRUE} once the local session has been cleared.
 #'
 #' @seealso \code{\link{ats_login}} for starting the session
 #'
@@ -119,18 +128,29 @@ ats_login <- function(usr, pwd) {
 #'
 ats_logout <- function() {
 
-  # log out of ATS website
-  httr::RETRY(
-    "POST",
-    url = ats_base_url,
-    path = list("Servidor.ashx"),
-    body = list(
-      consulta = "logout"
-    ),
-    encode = "form",
-    quiet = TRUE
-  ) %>%
-    httr::stop_for_status("log out")
+  # Best-effort server-side logout. On Windows, newer libcurl (>= 8.x, bundled
+  # with R >= 4.5) can fail this request with schannel SEC_E_CONTEXT_EXPIRED on
+  # a reused TLS connection (curl#18029) even though the server still ends the
+  # session. A transport-layer failure here must not stop us from clearing the
+  # local session below.
+  try(
+    httr::RETRY(
+      "POST",
+      url = ats_base_url,
+      path = list("Servidor.ashx"),
+      body = list(
+        consulta = "logout"
+      ),
+      encode = "form",
+      quiet = TRUE
+    ) %>%
+      httr::stop_for_status("log out"),
+    silent = TRUE
+  )
+
+  # Reset the handle to drop cookies and the stale TLS context, so the local
+  # session is cleared and the next login starts from a fresh connection.
+  httr::handle_reset(ats_base_url)
 
   # return true if user cookie is gone
   (!check_cookie(ats_base_url, "user"))

--- a/man/ats_logout.Rd
+++ b/man/ats_logout.Rd
@@ -7,11 +7,22 @@
 ats_logout()
 }
 \value{
-True if log out request is successful, false if log out fails
+\code{TRUE} once the local session has been cleared.
 }
 \description{
-Logs out of website
+Logs out of the ATS website and clears the local session.
 }
+\section{Notes}{
+
+
+  The server-side logout request is best-effort. On Windows, newer versions
+  of libcurl (bundled with R >= 4.5) can fail the request with a schannel
+  \code{SEC_E_CONTEXT_EXPIRED} error on a reused TLS connection (\code{curl}
+  issue 18029) even though the session is closed on the server. That
+  transport error is caught and ignored; the local session is always cleared
+  by resetting the connection handle.
+}
+
 \examples{
 \dontrun{
 

--- a/tests/testthat/test-fetch_ats.R
+++ b/tests/testthat/test-fetch_ats.R
@@ -125,6 +125,28 @@ test_that("Check ats login function", {
 
 })
 
+test_that("ats_logout tolerates a transport error and clears the session", {
+
+  skip_if_not_installed("mockery")
+
+  # Newer R bundles libcurl >= 8.x, which on Windows can fail the logout
+  # request with schannel SEC_E_CONTEXT_EXPIRED on a reused TLS connection
+  # (curl#18029). Simulate that by forcing the logout request to throw.
+  reset <- mockery::mock()
+  mockery::stub(
+    ats_logout,
+    "httr::RETRY",
+    function(...) stop("schannel: SEC_E_CONTEXT_EXPIRED")
+  )
+  mockery::stub(ats_logout, "httr::handle_reset", reset)
+
+  # logout should swallow the error, reset the handle to clear the local
+  # session, and still report success rather than erroring out
+  expect_true(ats_logout())
+  mockery::expect_called(reset, 1)
+
+})
+
 test_that("Check ATS data functions", {
 
   check_api()


### PR DESCRIPTION
Newer libcurl (bundled with R >= 4.5) can fail the ATS logout request on Windows with schannel SEC_E_CONTEXT_EXPIRED on a reused TLS connection (curl#18029), even though the server still ends the session. ats_logout() now catches that transport error and always resets the connection handle, so logout no longer errors and the next login starts from a fresh connection. Adds a mockery-based regression test; bumps to 0.0.7.